### PR TITLE
Draft: added api key based auth

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -15,11 +15,14 @@ Create a new Icinga Director Import Source and use "ServiceNow Table API" as the
 An official list of available tables can be found [here](https://www.servicenow.com/docs/bundle/yokohama-servicenow-platform/page/product/configuration-management/reference/cmdb-tables-details.html?state=seamless).
 Since we wanted to make it as customizable as possible, we don't have a hard-coded API method. Therefore, you have to provide the full endpoint for the table here (e.g. `api/now/table/cmdb_ci_server`).
 
+**Servicenow Auth Methos:** Allows you to chosse between basic auth and token based auth as described in https://www.servicenow.com/docs/bundle/zurich-platform-security/page/integrate/authentication/task/configure-api-key.html
+
 **ServiceNow API Username:** User to authenticate against the ServiceNow API.
-Currently only Basic Auth is supported to authenticate against ServiceNow.
 This user needs to have read access to the table you want to import.
 
 **ServiceNow API Password:** Password to authenticate against the ServiceNow API.
+
+**ServiceNow API Key:** API Key for token based auth
 
 **ServiceNow API Timeout:** Timeout for the API request in seconds. Default is `20` seconds.
 

--- a/library/Servicenowimport/Api/Servicenow.php
+++ b/library/Servicenowimport/Api/Servicenow.php
@@ -12,7 +12,7 @@ class Servicenow
 {
     protected $client = null;
 
-    public function __construct(string $baseUri, string $username, string $password, bool $tlsVerify = true, int $timeout = 10)
+    public function __construct(string $baseUri, string $username, string $password, string $apikey, bool $tlsVerify = true, int $timeout = 10)
     {
         $this->client = new Client(
             [
@@ -21,6 +21,7 @@ class Servicenow
                 'timeout' => $timeout,
                 'verify' => $tlsVerify,
                 'headers' => [
+                    'x-sn-apikey' => $apikey,
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
                 ],

--- a/library/Servicenowimport/ProvidedHook/Director/ImportSource.php
+++ b/library/Servicenowimport/ProvidedHook/Director/ImportSource.php
@@ -45,28 +45,59 @@ class ImportSource extends ImportSourceHook
                 'description' => 'API endpoint to fetch objects from (e.g.: api/now/table/cmdb_ci_computer)',
             ]
         );
-
         $form->addElement(
-            'text',
-            'servicenow_username',
+            'select',
+            'servicenow_authmethod',
             [
-                'label' => 'ServiceNow API Username',
+                'label' => 'ServiceNow API Auth-Method',
                 'required' => true,
-                'description' => 'Username to authenticate at the ServiceNow API',
+                'multiOptions' => [
+                    'basic' => ('Username & Password'),
+                    'apikey' => 'API-Key',
+		],
+		'class' => 'autosubmit',
+                'description' => 'Auth Method to authenticate at the ServiceNOW API (Basic Auth or Token-based Auth',
             ]
-        );
+	    );
 
-        $form->addElement(
-            'password',
-            'servicenow_password',
-            [
-                'label' => 'ServiceNow API Password',
-                'required' => true,
-                'renderPassword' => true,
-                'description' => 'Password to authenticate at the ServiceNow API',
-            ]
-        );
+	    $snowAuthmethod = $form->getSentOrObjectSetting('servicenow_authmethod');
 
+	    if($snowAuthmethod) {
+	        if ($snowAuthmethod === 'basic') {
+	            $form->addElement(
+                    'text',
+                    'servicenow_username',
+                    [
+                        'label' => 'ServiceNow API Username',
+                        'required' => true,
+                        'description' => 'Username to authenticate at the ServiceNow API',
+                    ]
+                );
+    
+                $form->addElement(
+                    'password',
+                    'servicenow_password',
+                    [
+                        'label' => 'ServiceNow API Password',
+                        'required' => true,
+                        'renderPassword' => true,
+                        'description' => 'Password to authenticate at the ServiceNow API',
+                    ]
+                );    
+	        } elseif ($snowAuthmethod === 'apikey') {
+                $form->addElement(
+                        'password',
+                        'servicenow_apikey',
+                        [
+                            'label' => 'ServiceNow API Key',
+                            'required' => true,
+                            'renderPassword' => true,
+                            'description' => 'API-Key to authenticate at the ServiceNow API',
+	    	        ]
+	            );
+            }
+        }
+    
         $form->addElement(
             'text',
             'servicenow_timeout',
@@ -162,6 +193,7 @@ class ImportSource extends ImportSourceHook
             $this->getSetting('servicenow_url'),
             $this->getSetting('servicenow_username'),
             $this->getSetting('servicenow_password'),
+            $this->getSetting('servicenow_apikey'),
             self::CLIENT_TLS_VERIFY,
             $this->getSetting('servicenow_timeout') ?: self::CLIENT_TIMEOUT,
         );


### PR DESCRIPTION
First, i am not a PHP Developer. 
This PR adds API-Key based authentication as described in https://www.servicenow.com/docs/bundle/zurich-platform-security/page/integrate/authentication/task/configure-api-key.html to the Import Source. There is a Selector allowing you to choose between Basic Auth and Key auth in the Configuration Form. 
Right now the Module tries authenticating in both ways in the Servicenow.php - i think i should improve this later on to only use one of these?

