### PR TITLE
Use sysparm_display_value to expand referenced objects

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -21,6 +21,8 @@ Since we wanted to make it as customizable as possible, we don't have a hard-cod
 
 Per default, we fetch all available columns. In case you want to limit the columns, you can provide a comma separated list of columns here. (e.g. `name,ip_address`)
 
+Note, The query uses the `sysparm_display_value` to expand referenced objects so that they can be used in columns.
+
 **ServiceNow Query:** Filters for the query.
 
 Per default, no filter limitation is applied to the query. The whole table will be fetched. In case you want to limit the objects, you can provide a filter query here.

--- a/library/Servicenowimport/Api/Servicenow.php
+++ b/library/Servicenowimport/Api/Servicenow.php
@@ -2,6 +2,8 @@
 
 namespace Icinga\Module\Servicenowimport\Api;
 
+use Icinga\Util\Json;
+
 use GuzzleHttp\Client;
 use RuntimeException;
 
@@ -112,7 +114,7 @@ class Servicenow
 
         try {
             $response = $c->post('/oauth_token.do', ['form_params' => $params]);
-            $data = json_decode($response->getBody(), true);
+            $data = Json::decode($response->getBody(), true);
         } catch (\Exception $e) {
             throw new RuntimeException(sprintf("Request failed: %s", $e->getMessage()));
         }

--- a/library/Servicenowimport/ProvidedHook/Director/ImportSource.php
+++ b/library/Servicenowimport/ProvidedHook/Director/ImportSource.php
@@ -2,17 +2,20 @@
 
 namespace Icinga\Module\Servicenowimport\ProvidedHook\Director;
 
-use GuzzleHttp\Exception\GuzzleException;
+use Icinga\Module\Servicenowimport\Api\Servicenow;
+
 use Icinga\Module\Director\Hook\ImportSourceHook;
 use Icinga\Module\Director\Web\Form\QuickForm;
-use Icinga\Module\Servicenowimport\Api\Servicenow;
+use Icinga\Util\Json;
+
+use GuzzleHttp\Exception\GuzzleException;
 
 class ImportSource extends ImportSourceHook
 {
-    private $objectCache = null;
+    private ?array $objectCache = null;
 
-    const CLIENT_TIMEOUT = 20;
-    const CLIENT_TLS_VERIFY = true;
+    private const CLIENT_TIMEOUT = 20;
+    private const CLIENT_TLS_VERIFY = true;
 
     public function getName()
     {
@@ -268,7 +271,7 @@ class ImportSource extends ImportSourceHook
             ]
         );
 
-        $data = json_decode($result, true);
+        $data = Json::decode($result, true);
 
         $result = $this->extractDisplayValues($data['result'] ?? []);
 

--- a/library/Servicenowimport/ProvidedHook/Director/ImportSource.php
+++ b/library/Servicenowimport/ProvidedHook/Director/ImportSource.php
@@ -233,7 +233,7 @@ class ImportSource extends ImportSourceHook
         }
 
         // Set endpoint
-        $endpoint = sprintf('%s?sysparm_display_value=true', $this->getSetting('servicenow_endpoint'));
+        $endpoint = $this->getSetting('servicenow_endpoint');
 
         $auth = [
             'method' => $this->getSetting('servicenow_authmethod'),
@@ -261,13 +261,35 @@ class ImportSource extends ImportSourceHook
             $endpoint,
             [
                 'query' => [
+                    'sysparm_display_value' => 'true',
                     'sysparm_fields' => $columns,
                     'sysparm_query' => rawurldecode($query),
                 ]
             ]
         );
 
-        return json_decode($result)->result;
+        $data = json_decode($result, true);
+
+        $result = $this->extractDisplayValues($data['result'] ?? []);
+
+        return $result;
+    }
+
+    /*
+     * extractDisplayValues returns a copy of the given array but with
+     * the with display_value as the values instead of objects.
+     * We use sysparm_display_value the expand the ServiceNow objects.
+     * each object will have the actual value in the field display_value.
+     */
+    protected function extractDisplayValues(array $array): array
+    {
+        return array_map(function ($value) {
+            if (!is_array($value)) {
+                return $value;
+            }
+
+            return array_key_exists('display_value', $value) ? $value['display_value'] : $this->extractDisplayValues($value);
+        }, $array);
     }
 
     protected static function addProxy(QuickForm $form)


### PR DESCRIPTION
We now use the `sysparm_display_value` URL param to expand referenced objects.

Now all returned values can be used in columns:

> name	company	vendor
> Service-now Production Sacramento	ACME Corporation	Dell Inc.
> Service-now Production San Diego	ACME Corporation	Dell Inc.

Fixes #16 